### PR TITLE
master

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ import chronos
 setup(name='chronospy',
       version=chronos.__version__,
       description='Mutil-thread/mutil-process task scheduler drive by Tornado IOLoop for human.',
-      long_description=open('README.rst').read() + "\n\n" + open('CHANGES').read(),
+      # TODO: Get rid of this or find a clean solution
+      #long_description=open('README.rst').read() + "\n\n" + open('CHANGES').read(),
       author="Thomas Huang",
       url='https://github.com/thomashuang/chronos',
       author_email='lyanghwy@gmail.com',


### PR DESCRIPTION
setup.py shouldn't try to read text files which makes pip install chronospy fail.
